### PR TITLE
Fix postgres to be TCP

### DIFF
--- a/app/products-api.yaml
+++ b/app/products-api.yaml
@@ -30,7 +30,7 @@ metadata:
 data:
   config: |
     {
-      "db_connection": "host=postgres port=5432 user=postgres password=password dbname=products sslmode=disable",
+      "db_connection": "host=localhost port=5432 user=postgres password=password dbname=products sslmode=disable",
       "bind_address": ":9090",
       "metrics_address": ":9103"
     }

--- a/app/products-db.yaml
+++ b/app/products-db.yaml
@@ -41,6 +41,7 @@ spec:
         prometheus.io/scrape: "true"
         prometheus.io/port: "9102"
         consul.hashicorp.com/connect-inject: "true"
+        consul.hashicorp.com/connect-service-protocol: "tcp"
     spec:
       serviceAccountName: postgres
       containers:

--- a/app/products-db.yaml
+++ b/app/products-db.yaml
@@ -56,6 +56,8 @@ spec:
               value: postgres
             - name: POSTGRES_PASSWORD
               value: password
+          # only listen on loopback so only access is via connect proxy
+          args: ["-c", "listen_addresses=127.0.0.1"]
           volumeMounts:
             - mountPath: "/var/lib/postgresql/data"
               name: "pgdata"


### PR DESCRIPTION
Since we set the default protocol to HTTP this service inherits that and so doesn't get any useful metrics output. It's a little surprising to me it works at all passing postgress wire protocol through an Envoy configured for HTTP but apparently it does!